### PR TITLE
Add MIME type for JavaScript files in app.py

### DIFF
--- a/py-src/data_formulator/app.py
+++ b/py-src/data_formulator/app.py
@@ -46,6 +46,8 @@ load_dotenv(os.path.join(APP_ROOT, "..", "..", 'openai-keys.env'))
 load_dotenv(os.path.join(APP_ROOT, 'openai-keys.env'))
 
 import os
+import mimetypes
+mimetypes.add_type('application/javascript', '.js')
 
 app = Flask(__name__, static_url_path='', static_folder=os.path.join(APP_ROOT, "dist"))
 CORS(app)


### PR DESCRIPTION
### Description

The code changes in this pull request modify the `app.py` file in the `data_formulator` module. Specifically, the change includes importing the `mimetypes` module and adding a new mapping for `application/javascript` files to the `.js` extension.


- Import the `mimetypes` module.
- Add a new mapping in `mimetypes` for `application/javascript` files to the `.js` extension.